### PR TITLE
Update Azure Pipelines configuration and add starter pipeline.  TACE …

### DIFF
--- a/azure-pipelines.yml.bak
+++ b/azure-pipelines.yml.bak
@@ -9,7 +9,7 @@ trigger:
 pr: none
 
 pool:
-  vmImage: 'windows-2022'
+  vmImage: 'windows-latest'
   demands:
   - msbuild
   - visualstudio


### PR DESCRIPTION
…is asking about why we get errors in our build.  I think it has something to do with this error:

##[warning]The windows-2019 runner image is being deprecated, consider switching to windows-2022(windows-latest) or windows-2025 instead. For more details see https://github.com/actions/runner-images/issues/12045.